### PR TITLE
Bundle polyfill with component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 .DS_Store
+_tmp

--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="node_modules/document-register-element/build/document-register-element.js"></script>
-    <script src="./dist/bundle.js"></script>
+    <!-- <script src="node_modules/document-register-element/build/document-register-element.js"></script> -->
+    <script src="./dist/polyfilled-bundle.js"></script>
   </head>
   <body>
     <filtering-search-bar>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "npm run build && npm run server",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run compile && npm run bundle && npm run combine",
-    "compile": "babel src -d dist --blacklist es6.modules -e 0",
-    "bundle": "rollup dist/index.js -o dist/bundle.js",
+    "compile": "babel src -d _tmp --blacklist es6.modules -e 0",
+    "bundle": "rollup _tmp/index.js -o dist/bundle.js",
     "combine": "uglifyjs node_modules/document-register-element/build/document-register-element.js dist/bundle.js -o dist/polyfilled-bundle.js",
     "server": "http-server"
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "npm run compile && npm run bundle && npm run server",
+    "start": "npm run build && npm run server",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "npm run compile && npm run bundle && npm run combine",
     "compile": "babel src -d dist --blacklist es6.modules -e 0",
     "bundle": "rollup dist/index.js -o dist/bundle.js",
+    "combine": "uglifyjs node_modules/document-register-element/build/document-register-element.js dist/bundle.js -o dist/polyfilled-bundle.js",
     "server": "http-server"
   },
   "author": "",
@@ -15,7 +17,8 @@
   "devDependencies": {
     "babel": "^5.8.21",
     "http-server": "^0.8.0",
-    "rollup": "^0.12.1"
+    "rollup": "^0.12.1",
+    "uglify-js": "^2.4.24"
   },
   "dependencies": {
     "document-register-element": "^0.4.5"

--- a/src/filtering-search-bar.js
+++ b/src/filtering-search-bar.js
@@ -19,7 +19,7 @@ class FilteringSearchBar extends HTMLElement {
     this.input.addEventListener('keypress', this.handleInput.bind(this));
     this.input.addEventListener('focus', this.handleInput.bind(this));
     this.input.addEventListener('input', this.handleInput.bind(this));
-    this.input.addEventListener('blur', this.handleBlur.bind(this));
+    //this.input.addEventListener('blur', this.handleBlur.bind(this));
   }
 
   @log
@@ -28,7 +28,7 @@ class FilteringSearchBar extends HTMLElement {
     this.input.removeEventListener('keypress', this.handleInput.bind(this));
     this.input.addEventListener('focus', this.handleInput.bind(this));
     this.input.removeEventListener('input', this.handleInput.bind(this));
-    this.input.addEventListener('blur', this.handleBlur.bind(this));
+    //this.input.addEventListener('blur', this.handleBlur.bind(this));
   }
 
   @log


### PR DESCRIPTION
As I went through this and started to grok it, I thought it might be nice to be able to include the component with a single script tag. So I added a step to concatenate the polyfill with the bundle.

This seems to me to be a good idea. Unless you wanted to only conditionally include the polyfill like:

```
<script>
    if ('registerElement' in document
      && 'createShadowRoot' in HTMLElement.prototype
      && 'import' in document.createElement('link')
      && 'content' in document.createElement('template')) {
      // We're using a browser with native WC support!
    } else {
      document.write('<script src="node_modules/document-register-element/build/document-register-element.js"></script>')
    }
  </script>
```

I also changed the build to put intermediate files into a _tmp directory. The dist directory now only contains the full compiled bundle.
